### PR TITLE
Use explicit http link for ots discourse

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
           Participation will not be require to have RustFest Ticket: anyone is invited to come.
         </p>
         </br>
-        <h4>Don't hesitate to<a href="//discourse.opentechschool.org/t/rustbridge-workshop-sept-18th-berlin-together-with-rustfest/1849"> Sign up!</a><h3>
+        <h4>Don't hesitate to<a href="http://discourse.opentechschool.org/t/rustbridge-workshop-sept-18th-berlin-together-with-rustfest/1849"> Sign up!</a><h3>
         </h4>
       </div>
     </div>


### PR DESCRIPTION
Currently the OTS discourse does not use HTTPS, so this needs an explicit http link
